### PR TITLE
C# notebooks now restore from embedded local packages first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ipynb_checkpoints/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ This repository contains Jupyter notebooks to request analytics and retrieve bes
 ## Useful links
 
 - [Systemathics website](https://www.systemathics.com/) 
--  [Systemathics data offer website](https://systemathics.cloud/)
+- [Systemathics data offer website](https://systemathics.cloud/)
 - [Ganymede](https://ganymede.cloud): credentials required to access Jupyter environment
 - [Documentation](https://systemathics.cloud/api-documentation.html): includes API documentation and tutorials (authentication, services, request parameters, reply formats...)

--- a/csharp/1-Reference data/exchange_data.ipynb
+++ b/csharp/1-Reference data/exchange_data.ipynb
@@ -69,6 +69,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: CsvHelper\""
    ]

--- a/csharp/1-Reference data/index_components.ipynb
+++ b/csharp/1-Reference data/index_components.ipynb
@@ -64,6 +64,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: CsvHelper\""
    ]

--- a/csharp/1-Reference data/index_weights.ipynb
+++ b/csharp/1-Reference data/index_weights.ipynb
@@ -64,6 +64,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\r\n",
     "#r \"nuget: CsvHelper\"\r\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""

--- a/csharp/1-Reference data/symbology.ipynb
+++ b/csharp/1-Reference data/symbology.ipynb
@@ -67,6 +67,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\""
    ]
   },

--- a/csharp/2-Corporate actions/dividends.ipynb
+++ b/csharp/2-Corporate actions/dividends.ipynb
@@ -54,6 +54,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\""
    ]
   },

--- a/csharp/2-Corporate actions/splits.ipynb
+++ b/csharp/2-Corporate actions/splits.ipynb
@@ -54,6 +54,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\""
    ]
   },

--- a/csharp/3-Market data/Daily/[DailyData] bars.ipynb
+++ b/csharp/3-Market data/Daily/[DailyData] bars.ipynb
@@ -55,6 +55,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/3-Market data/Daily/[DailyData] gafam.ipynb
+++ b/csharp/3-Market data/Daily/[DailyData] gafam.ipynb
@@ -58,6 +58,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget:Systemathics.Apis\"\r\n",
     "#r \"nuget: XPlot.Plotly\"\r\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""

--- a/csharp/3-Market data/Daily/[DailyData] prices.ipynb
+++ b/csharp/3-Market data/Daily/[DailyData] prices.ipynb
@@ -55,6 +55,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/3-Market data/Daily/[DailyData] vwap.ipynb
+++ b/csharp/3-Market data/Daily/[DailyData] vwap.ipynb
@@ -62,6 +62,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/3-Market data/Intraday/[Intraday] export_L1L2_ticks.ipynb
+++ b/csharp/3-Market data/Intraday/[Intraday] export_L1L2_ticks.ipynb
@@ -57,6 +57,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget:CsvHelper\""
    ]

--- a/csharp/3-Market data/Intraday/[Intraday] export_raw_ticks.ipynb
+++ b/csharp/3-Market data/Intraday/[Intraday] export_raw_ticks.ipynb
@@ -49,6 +49,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\""
    ]
   },

--- a/csharp/3-Market data/Intraday/[Intraday] top_of_book.ipynb
+++ b/csharp/3-Market data/Intraday/[Intraday] top_of_book.ipynb
@@ -54,6 +54,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]
@@ -340,7 +342,7 @@
    "source": []
   }
  ],
-  "metadata": {
+ "metadata": {
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",

--- a/csharp/3-Market data/Intraday/[Intraday] topofbook_and_trades.ipynb
+++ b/csharp/3-Market data/Intraday/[Intraday] topofbook_and_trades.ipynb
@@ -54,6 +54,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/3-Market data/Intraday/[Intraday] trades.ipynb
+++ b/csharp/3-Market data/Intraday/[Intraday] trades.ipynb
@@ -54,6 +54,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/4-Analytics/Daily data/[DailyData] volatility.ipynb
+++ b/csharp/4-Analytics/Daily data/[DailyData] volatility.ipynb
@@ -59,6 +59,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\""
    ]
   },

--- a/csharp/4-Analytics/Daily data/[dailydata] bollinger_bands.ipynb
+++ b/csharp/4-Analytics/Daily data/[dailydata] bollinger_bands.ipynb
@@ -60,6 +60,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/4-Analytics/Daily data/[dailydata] cma.ipynb
+++ b/csharp/4-Analytics/Daily data/[dailydata] cma.ipynb
@@ -64,6 +64,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/4-Analytics/Daily data/[dailydata] ema.ipynb
+++ b/csharp/4-Analytics/Daily data/[dailydata] ema.ipynb
@@ -78,6 +78,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/4-Analytics/Daily data/[dailydata] macd.ipynb
+++ b/csharp/4-Analytics/Daily data/[dailydata] macd.ipynb
@@ -68,6 +68,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/4-Analytics/Daily data/[dailydata] rsi.ipynb
+++ b/csharp/4-Analytics/Daily data/[dailydata] rsi.ipynb
@@ -67,6 +67,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/4-Analytics/Daily data/[dailydata] sma.ipynb
+++ b/csharp/4-Analytics/Daily data/[dailydata] sma.ipynb
@@ -71,6 +71,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/4-Analytics/Intraday/[Intraday] bars.ipynb
+++ b/csharp/4-Analytics/Intraday/[Intraday] bars.ipynb
@@ -55,6 +55,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/4-Analytics/Intraday/[Intraday] bollinger_bands.ipynb
+++ b/csharp/4-Analytics/Intraday/[Intraday] bollinger_bands.ipynb
@@ -60,6 +60,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/4-Analytics/Intraday/[Intraday] cma.ipynb
+++ b/csharp/4-Analytics/Intraday/[Intraday] cma.ipynb
@@ -64,6 +64,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/4-Analytics/Intraday/[Intraday] ema.ipynb
+++ b/csharp/4-Analytics/Intraday/[Intraday] ema.ipynb
@@ -78,6 +78,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/4-Analytics/Intraday/[Intraday] execution_ratio.ipynb
+++ b/csharp/4-Analytics/Intraday/[Intraday] execution_ratio.ipynb
@@ -62,6 +62,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/4-Analytics/Intraday/[Intraday] market_activity.ipynb
+++ b/csharp/4-Analytics/Intraday/[Intraday] market_activity.ipynb
@@ -66,6 +66,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/4-Analytics/Intraday/[Intraday] mid.ipynb
+++ b/csharp/4-Analytics/Intraday/[Intraday] mid.ipynb
@@ -66,6 +66,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/4-Analytics/Intraday/[Intraday] sma.ipynb
+++ b/csharp/4-Analytics/Intraday/[Intraday] sma.ipynb
@@ -71,6 +71,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/4-Analytics/Intraday/[Intraday] spread.ipynb
+++ b/csharp/4-Analytics/Intraday/[Intraday] spread.ipynb
@@ -66,6 +66,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/4-Analytics/Intraday/[Intraday] vwap.ipynb
+++ b/csharp/4-Analytics/Intraday/[Intraday] vwap.ipynb
@@ -66,6 +66,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/5-Best execution/Interval/bestex_interval.ipynb
+++ b/csharp/5-Best execution/Interval/bestex_interval.ipynb
@@ -64,6 +64,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\"\n",
     "#r \"nuget: CsvHelper\""

--- a/csharp/5-Best execution/Point in time/bestex_pit_multiple.ipynb
+++ b/csharp/5-Best execution/Point in time/bestex_pit_multiple.ipynb
@@ -64,6 +64,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\"\n",
     "#r \"nuget: CsvHelper\""

--- a/csharp/5-Best execution/Point in time/bestex_pit_single.ipynb
+++ b/csharp/5-Best execution/Point in time/bestex_pit_single.ipynb
@@ -63,6 +63,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/6-Future roll/roll_marketactivity.ipynb
+++ b/csharp/6-Future roll/roll_marketactivity.ipynb
@@ -71,6 +71,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]

--- a/csharp/6-Future roll/roll_maturity.ipynb
+++ b/csharp/6-Future roll/roll_maturity.ipynb
@@ -70,6 +70,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#i \"nuget: file:///home/jovyan/.nuget/packages/\"\n",
+    "#i \"nuget: https://api.nuget.org/v3/index.json\"\n",
     "#r \"nuget: Systemathics.Apis\"\n",
     "#r \"nuget: XPlot.Plotly.Interactive\""
    ]


### PR DESCRIPTION
Take advantage of the newest docker images now embedding plotly NuGet packages (complete dependency graph).
This results in faster restore times (a few seconds, compared to minutes in previous versions) for C# notebooks, and better user experience.